### PR TITLE
Add option to autoload and autosave waymark presets

### DIFF
--- a/WaymarkPresetPlugin/Configuration.cs
+++ b/WaymarkPresetPlugin/Configuration.cs
@@ -73,6 +73,20 @@ namespace WaymarkPresetPlugin
 			set { mAllowDirectPlacePreset = value; }
 		}
 
+		public bool mAutoPopulatePresetsOnEnterInstance = false;
+		public bool AutoPopulatePresetsOnEnterInstance
+		{
+			get { return mAutoPopulatePresetsOnEnterInstance; }
+			set { mAutoPopulatePresetsOnEnterInstance = value; }
+		}
+
+		public bool mAutoSaveWaymarksOnInstanceLeave = false;
+		public bool AutoSaveWaymarksOnInstanceLeave
+		{
+			get { return mAutoSaveWaymarksOnInstanceLeave; }
+			set { mAutoSaveWaymarksOnInstanceLeave = value; }
+		}
+
 		public string GetZoneName( UInt16 ID )
 		{
 			return GetZoneNameDelegate( ID, ShowIDNumberNextToZoneNames );

--- a/WaymarkPresetPlugin/MemoryHandler.cs
+++ b/WaymarkPresetPlugin/MemoryHandler.cs
@@ -12,6 +12,8 @@ namespace WaymarkPresetPlugin
 {
 	public static class MemoryHandler
 	{
+		private static object writeLock = new object();
+
 		public static void Init( DalamudPluginInterface pluginInterface )
 		{
 			if( pluginInterface == null )
@@ -98,16 +100,19 @@ namespace WaymarkPresetPlugin
 
 		public static bool WriteSlot( uint slotNum, byte[] data )
 		{
-			IntPtr pWaymarkData = GetGameWaymarkDataPointerForSlot( slotNum );
-			if( data.Length >= 104 && pWaymarkData != IntPtr.Zero )
+			lock (writeLock)
 			{
-				//	Don't catch exceptions here; better to have the caller do it probably.
-				Marshal.Copy( data, 0, pWaymarkData, 104 );
-				return true;
-			}
-			else
-			{
-				return false;
+				IntPtr pWaymarkData = GetGameWaymarkDataPointerForSlot(slotNum);
+				if (data.Length >= 104 && pWaymarkData != IntPtr.Zero)
+				{
+					//	Don't catch exceptions here; better to have the caller do it probably.
+					Marshal.Copy(data, 0, pWaymarkData, 104);
+					return true;
+				}
+				else
+				{
+					return false;
+				}
 			}
 		}
 

--- a/WaymarkPresetPlugin/PluginUI.cs
+++ b/WaymarkPresetPlugin/PluginUI.cs
@@ -329,7 +329,7 @@ namespace WaymarkPresetPlugin
 					if( ImGui.Button( "Edit" ) && EditingPresetIndex == -1 )  //Don't want to let people start editing while the edit window is already open.
 					{
 						EditingPresetIndex = SelectedPreset;
-						ScratchEditingPreset = new ScratchPreset( mConfiguration.PresetLibrary.Presets[EditingPresetIndex] );
+						//ScratchEditingPreset = new ScratchPreset( mConfiguration.PresetLibrary.Presets[EditingPresetIndex] );
 					}
 					ImGui.SameLine();
 					ImGui.PushStyleColor( ImGuiCol.Text, 0xee4444ff );
@@ -384,106 +384,92 @@ namespace WaymarkPresetPlugin
 			ImGui.SetNextWindowSize( new Vector2( 375, 425 ) );
 			if( ImGui.Begin( "Preset Editor", ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize ) )
 			{
-				if( ScratchEditingPreset != null )
+				WaymarkPreset editingPreset = mConfiguration.PresetLibrary.Presets[EditingPresetIndex];
+				ImGui.Text( "Name: " );
+				ImGui.SameLine();
+				ImGui.InputText( "##PresetName", ref editingPreset.Name, 128 );
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.BeginGroup();
+				ImGui.Columns( 2 );
+				ImGui.SetColumnWidth(0, 50);
+				ImGui.Text( "Active" );
+				foreach( var waymark in editingPreset.Waymarks )
 				{
-					ImGui.Text( "Name: " );
+					ImGui.Checkbox( waymark.Label, ref waymark.Active );
+				}
+				ImGui.NextColumn();
+				ImGui.Text( "" );
+				foreach( var waymark in editingPreset.Waymarks )
+				{
+					var val = new Vector3(waymark.X / 1000f, waymark.Y / 1000f, waymark.Z / 1000f);
+					if (ImGui.InputFloat3( $"##{waymark.Label}-X", ref val ))
+					{
+						waymark.X = (int)(val.X * 1000f);
+						waymark.Y = (int)(val.Y * 1000f);
+						waymark.Z = (int)(val.Z * 1000f);
+					}
+				}
+				ImGui.Columns( 1 );
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Text( "Zone: " );
+				if( ImGui.BeginCombo( "##MapID", mConfiguration.GetZoneName(editingPreset.MapID ) ) )
+				{
+					ImGui.Text( "Search: " );
 					ImGui.SameLine();
-					ImGui.InputText( "##PresetName", ref ScratchEditingPreset.Name, 128 );
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.BeginGroup();
-					ImGui.Columns( 4 );
-					ImGui.Text( "Active" );
-					foreach( var waymark in ScratchEditingPreset.Waymarks )
+					ImGui.InputText( "##ZoneComboFilter", ref mEditWindowZoneFilterString, 16u );
+					if( !EditWindowZoneComboWasOpen )
 					{
-						ImGui.Checkbox( waymark.Label, ref waymark.Active );
+						ImGui.SetKeyboardFocusHere();
+						ImGui.SetItemDefaultFocus();
 					}
-					ImGui.NextColumn();
-					ImGui.Text( "X" );
-					foreach( var waymark in ScratchEditingPreset.Waymarks )
+					foreach( UInt16 zoneID in EditWindowZoneSearcher.GetMatchingZones( mEditWindowZoneFilterString ) )
 					{
-						ImGui.InputFloat( $"##{waymark.Label}-X", ref waymark.X );
-					}
-					ImGui.NextColumn();
-					ImGui.Text( "Y" );
-					foreach( var waymark in ScratchEditingPreset.Waymarks )
-					{
-						ImGui.InputFloat( $"##{waymark.Label}-Y", ref waymark.Y );
-					}
-					ImGui.NextColumn();
-					ImGui.Text( "Z" );
-					foreach( var waymark in ScratchEditingPreset.Waymarks )
-					{
-						ImGui.InputFloat( $"##{waymark.Label}-Z", ref waymark.Z );
-					}
-					ImGui.Columns( 1 );
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Text( "Zone: " );
-					if( ImGui.BeginCombo( "##MapID", mConfiguration.GetZoneName( ScratchEditingPreset.MapID ) ) )
-					{
-						ImGui.Text( "Search: " );
-						ImGui.SameLine();
-						ImGui.InputText( "##ZoneComboFilter", ref mEditWindowZoneFilterString, 16u );
-						if( !EditWindowZoneComboWasOpen )
+						if( zoneID != 0 && ImGui.Selectable( mConfiguration.GetZoneName( zoneID ), zoneID == editingPreset.MapID ) )
 						{
-							ImGui.SetKeyboardFocusHere();
-							ImGui.SetItemDefaultFocus();
+							editingPreset.MapID = zoneID;
 						}
-						foreach( UInt16 zoneID in EditWindowZoneSearcher.GetMatchingZones( mEditWindowZoneFilterString ) )
-						{
-							if( zoneID != 0 && ImGui.Selectable( mConfiguration.GetZoneName( zoneID ), zoneID == ScratchEditingPreset.MapID ) )
-							{
-								ScratchEditingPreset.MapID = zoneID;
-							}
 
-							//	Uncomment this if we can ever have a better location for the search/filter text box that's not actually in the combo dropdown.
-							/*if( zoneID == ScratchEditingPreset.MapID )
-							{
-								ImGui.SetItemDefaultFocus();
-							}*/
-						}
-						ImGui.EndCombo();
-						EditWindowZoneComboWasOpen = true;
-					}
-					else
-					{
-						EditWindowZoneComboWasOpen = false;
-						mEditWindowZoneFilterString = "";
-					}
-					ImGui.EndGroup();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					ImGui.Spacing();
-					if( ImGui.Button( "Save" ) )
-					{
-						try
+						//	Uncomment this if we can ever have a better location for the search/filter text box that's not actually in the combo dropdown.
+						/*if( zoneID == ScratchEditingPreset.MapID )
 						{
-							mConfiguration.PresetLibrary.Presets[EditingPresetIndex] = ScratchEditingPreset.GetPreset();
-							EditingPresetIndex = -1;
-							ScratchEditingPreset = null;
-							mConfiguration.Save();
-						}
-						catch
-						{
-						}
+							ImGui.SetItemDefaultFocus();
+						}*/
 					}
-					ImGui.SameLine();
+					ImGui.EndCombo();
+					EditWindowZoneComboWasOpen = true;
 				}
 				else
 				{
-					ImGui.Text( "Invalid editing data; something went very wrong.  Please press \"Cancel\" and try again." );
+					EditWindowZoneComboWasOpen = false;
+					mEditWindowZoneFilterString = "";
 				}
+				ImGui.EndGroup();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				ImGui.Spacing();
+				if( ImGui.Button( "Save" ) )
+				{
+					try
+					{
+						mConfiguration.Save();
+					}
+					catch
+					{
+					}
+					EditingPresetIndex = -1;
+				}
+				ImGui.SameLine();
 				
 
 				if( ImGui.Button( "Cancel" ) )
 				{
 					EditingPresetIndex = -1;
-					ScratchEditingPreset = null;
 				}
 			}
 			ImGui.End();
@@ -727,159 +713,11 @@ namespace WaymarkPresetPlugin
 		public bool WantToDeleteSelectedPreset { get; protected set; } = false;
 		public int EditingPresetIndex { get; protected set; } = -1;
 		public UInt16 CurrentTerritoryTypeID { get; set; }
-		protected  ScratchPreset ScratchEditingPreset { get; set; }
 		protected ZoneSearcher EditWindowZoneSearcher { get; set; } = new ZoneSearcher();
 		protected string mEditWindowZoneFilterString = "";
 		protected bool EditWindowZoneComboWasOpen { get; set; } = false;
 		protected Dictionary<UInt16, List<TextureWrap>> MapTextureDict { get; set; } = new Dictionary<UInt16, List<TextureWrap>>();
 		protected Mutex mMapTextureDictMutex = new Mutex();
 		protected int mSelectedMapIndex = 0;
-	}
-
-	//	We need this because we can't pass the properties from the regular Waymark class as refs to ImGui stuff.  It's an absolute dog's breakfast, but whatever at this point honestly.
-	public class ScratchPreset
-	{
-		public class ScratchWaymark
-		{
-			public float X;
-			public float Y;
-			public float Z;
-			public int ID;
-			public bool Active;
-			public string Label;
-		}
-
-		public ScratchPreset( WaymarkPreset preset )
-		{
-			Name = preset.Name;
-			MapID = preset.MapID;
-			Waymarks = new List<ScratchWaymark>();
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.A.X;
-			Waymarks.Last().Y = preset.A.Y;
-			Waymarks.Last().Z = preset.A.Z;
-			Waymarks.Last().ID = preset.A.ID;
-			Waymarks.Last().Active = preset.A.Active;
-			Waymarks.Last().Label = "A";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.B.X;
-			Waymarks.Last().Y = preset.B.Y;
-			Waymarks.Last().Z = preset.B.Z;
-			Waymarks.Last().ID = preset.B.ID;
-			Waymarks.Last().Active = preset.B.Active;
-			Waymarks.Last().Label = "B";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.C.X;
-			Waymarks.Last().Y = preset.C.Y;
-			Waymarks.Last().Z = preset.C.Z;
-			Waymarks.Last().ID = preset.C.ID;
-			Waymarks.Last().Active = preset.C.Active;
-			Waymarks.Last().Label = "C";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.D.X;
-			Waymarks.Last().Y = preset.D.Y;
-			Waymarks.Last().Z = preset.D.Z;
-			Waymarks.Last().ID = preset.D.ID;
-			Waymarks.Last().Active = preset.D.Active;
-			Waymarks.Last().Label = "D";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.One.X;
-			Waymarks.Last().Y = preset.One.Y;
-			Waymarks.Last().Z = preset.One.Z;
-			Waymarks.Last().ID = preset.One.ID;
-			Waymarks.Last().Active = preset.One.Active;
-			Waymarks.Last().Label = "1";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.Two.X;
-			Waymarks.Last().Y = preset.Two.Y;
-			Waymarks.Last().Z = preset.Two.Z;
-			Waymarks.Last().ID = preset.Two.ID;
-			Waymarks.Last().Active = preset.Two.Active;
-			Waymarks.Last().Label = "2";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.Three.X;
-			Waymarks.Last().Y = preset.Three.Y;
-			Waymarks.Last().Z = preset.Three.Z;
-			Waymarks.Last().ID = preset.Three.ID;
-			Waymarks.Last().Active = preset.Three.Active;
-			Waymarks.Last().Label = "3";
-
-			Waymarks.Add( new ScratchWaymark() );
-			Waymarks.Last().X = preset.Four.X;
-			Waymarks.Last().Y = preset.Four.Y;
-			Waymarks.Last().Z = preset.Four.Z;
-			Waymarks.Last().ID = preset.Four.ID;
-			Waymarks.Last().Active = preset.Four.Active;
-			Waymarks.Last().Label = "4";
-		}
-
-		public WaymarkPreset GetPreset()
-		{
-			WaymarkPreset newPreset = new WaymarkPreset();
-
-			newPreset.Name = Name;
-			newPreset.MapID = MapID;
-
-			newPreset.A.X = Waymarks[0].X;
-			newPreset.A.Y = Waymarks[0].Y;
-			newPreset.A.Z = Waymarks[0].Z;
-			newPreset.A.ID = Waymarks[0].ID;
-			newPreset.A.Active = Waymarks[0].Active;
-
-			newPreset.B.X = Waymarks[1].X;
-			newPreset.B.Y = Waymarks[1].Y;
-			newPreset.B.Z = Waymarks[1].Z;
-			newPreset.B.ID = Waymarks[1].ID;
-			newPreset.B.Active = Waymarks[1].Active;
-
-			newPreset.C.X = Waymarks[2].X;
-			newPreset.C.Y = Waymarks[2].Y;
-			newPreset.C.Z = Waymarks[2].Z;
-			newPreset.C.ID = Waymarks[2].ID;
-			newPreset.C.Active = Waymarks[2].Active;
-
-			newPreset.D.X = Waymarks[3].X;
-			newPreset.D.Y = Waymarks[3].Y;
-			newPreset.D.Z = Waymarks[3].Z;
-			newPreset.D.ID = Waymarks[3].ID;
-			newPreset.D.Active = Waymarks[3].Active;
-
-			newPreset.One.X = Waymarks[4].X;
-			newPreset.One.Y = Waymarks[4].Y;
-			newPreset.One.Z = Waymarks[4].Z;
-			newPreset.One.ID = Waymarks[4].ID;
-			newPreset.One.Active = Waymarks[4].Active;
-
-			newPreset.Two.X = Waymarks[5].X;
-			newPreset.Two.Y = Waymarks[5].Y;
-			newPreset.Two.Z = Waymarks[5].Z;
-			newPreset.Two.ID = Waymarks[5].ID;
-			newPreset.Two.Active = Waymarks[5].Active;
-
-			newPreset.Three.X = Waymarks[6].X;
-			newPreset.Three.Y = Waymarks[6].Y;
-			newPreset.Three.Z = Waymarks[6].Z;
-			newPreset.Three.ID = Waymarks[6].ID;
-			newPreset.Three.Active = Waymarks[6].Active;
-
-			newPreset.Four.X = Waymarks[7].X;
-			newPreset.Four.Y = Waymarks[7].Y;
-			newPreset.Four.Z = Waymarks[7].Z;
-			newPreset.Four.ID = Waymarks[7].ID;
-			newPreset.Four.Active = Waymarks[7].Active;
-
-			return newPreset;
-		}
-
-		public string Name = "";
-		public UInt16 MapID = 0;
-		public List<ScratchWaymark> Waymarks;
 	}
 }

--- a/WaymarkPresetPlugin/PluginUI.cs
+++ b/WaymarkPresetPlugin/PluginUI.cs
@@ -329,7 +329,6 @@ namespace WaymarkPresetPlugin
 					if( ImGui.Button( "Edit" ) && EditingPresetIndex == -1 )  //Don't want to let people start editing while the edit window is already open.
 					{
 						EditingPresetIndex = SelectedPreset;
-						//ScratchEditingPreset = new ScratchPreset( mConfiguration.PresetLibrary.Presets[EditingPresetIndex] );
 					}
 					ImGui.SameLine();
 					ImGui.PushStyleColor( ImGuiCol.Text, 0xee4444ff );

--- a/WaymarkPresetPlugin/PluginUI.cs
+++ b/WaymarkPresetPlugin/PluginUI.cs
@@ -496,7 +496,7 @@ namespace WaymarkPresetPlugin
 				return;
 			}
 
-			ImGui.SetNextWindowSize( new Vector2( 350, 310 ) );
+			ImGui.SetNextWindowSize( new Vector2( 350, 350 ) );
 			if( ImGui.Begin( "Waymark Settings", ref mSettingsWindowVisible,
 				ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse ) )
 			{
@@ -508,7 +508,9 @@ namespace WaymarkPresetPlugin
 				ImGui.Checkbox( "Show ID numbers next to zone names.", ref mConfiguration.mShowIDNumberNextToZoneNames );
 				ImGui.Checkbox( "Show the index of the preset within the library.", ref mConfiguration.mShowLibraryIndexInPresetList );
 				ImGui.Checkbox( "Allow placement of presets directly from the library*.", ref mConfiguration.mAllowDirectPlacePreset );
-				ImGui.Text( "*Please read the plugin site's readme before enabling this." );
+                ImGui.Checkbox( "Autoload waymarks from preset library.", ref mConfiguration.mAutoPopulatePresetsOnEnterInstance);
+                ImGui.Checkbox( "Autosave waymarks to preset library.", ref mConfiguration.mAutoSaveWaymarksOnInstanceLeave);
+                ImGui.Text( "*Please read the plugin site's readme before enabling this." );
 				if( !mConfiguration.ShowFilterOnCurrentZoneCheckbox ) FilterOnCurrentZone = false;
 				ImGui.Spacing();
 				if( ImGui.Button( "Save and Close" ) )
@@ -724,8 +726,8 @@ namespace WaymarkPresetPlugin
 		public int SelectedPreset { get; protected set; } = -1;
 		public bool WantToDeleteSelectedPreset { get; protected set; } = false;
 		public int EditingPresetIndex { get; protected set; } = -1;
+		public UInt16 CurrentTerritoryTypeID { get; set; }
 		protected  ScratchPreset ScratchEditingPreset { get; set; }
-		protected UInt16 CurrentTerritoryTypeID { get; set; }
 		protected ZoneSearcher EditWindowZoneSearcher { get; set; } = new ZoneSearcher();
 		protected string mEditWindowZoneFilterString = "";
 		protected bool EditWindowZoneComboWasOpen { get; set; } = false;

--- a/WaymarkPresetPlugin/Waymark.cs
+++ b/WaymarkPresetPlugin/Waymark.cs
@@ -12,6 +12,11 @@ namespace WaymarkPresetPlugin
 		{
 		}
 
+		public Waymark(string Label)
+		{
+			this.Label = Label;
+		}
+		
 		public Waymark( Waymark objToCopy )
 		{
 			if( objToCopy != null )
@@ -25,20 +30,21 @@ namespace WaymarkPresetPlugin
 		}
 		public string GetWaymarkDataString()
 		{
-			return Active ? ( X.ToString( "0.00" ).PadLeft( 7 ) + ", " + Y.ToString( "0.00" ).PadLeft( 7 ) + ", " + Z.ToString( "0.00" ).PadLeft( 7 ) ) : "Unused";
+			return Active ? ( (X / 1000f).ToString( "0.00" ).PadLeft( 7 ) + ", " + (Y / 1000f).ToString( "0.00" ).PadLeft( 7 ) + ", " + (Z / 1000f).ToString( "0.00" ).PadLeft( 7 ) ) : "Unused";
 		}
 
-		public float X { get; set; } = 0.0f;
-		public float Y { get; set; } = 0.0f;
-		public float Z { get; set; } = 0.0f;
+		public int X { get; set; } = 0;
+		public int Y { get; set; } = 0;
+		public int Z { get; set; } = 0;
 		public int ID { get; set; } = 0;	//This is kind of a BS field, but keep it for import/export interop with PP.
-		public bool Active { get; set; } = false;
+		public string Label { get; set; }
+		public bool Active = false;
 
 		public bool Equals(Waymark other)
 		{
-			return Math.Abs(X - other.X) < 0.02f
-				&& Math.Abs(X - other.X) < 0.02f
-				&& Math.Abs(Z - other.Z) < 0.02f;
+			return X == other.X
+				&& Y == other.Y
+				&& Z == other.Z;
 		}
 	}
 }

--- a/WaymarkPresetPlugin/Waymark.cs
+++ b/WaymarkPresetPlugin/Waymark.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace WaymarkPresetPlugin
 {
-	public class Waymark
+	public class Waymark : IEquatable<Waymark>
 	{
 		public Waymark()
 		{
@@ -33,5 +33,12 @@ namespace WaymarkPresetPlugin
 		public float Z { get; set; } = 0.0f;
 		public int ID { get; set; } = 0;	//This is kind of a BS field, but keep it for import/export interop with PP.
 		public bool Active { get; set; } = false;
+
+		public bool Equals(Waymark other)
+		{
+			return Math.Abs(X - other.X) < 0.02f
+				&& Math.Abs(X - other.X) < 0.02f
+				&& Math.Abs(Z - other.Z) < 0.02f;
+		}
 	}
 }

--- a/WaymarkPresetPlugin/WaymarkPreset.cs
+++ b/WaymarkPresetPlugin/WaymarkPreset.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace WaymarkPresetPlugin
 {
 	[JsonObject( ItemNullValueHandling = NullValueHandling.Ignore )]	//	Shouldn't have any null waymarks, but just in case...
-	public class WaymarkPreset
+	public class WaymarkPreset : IEquatable<WaymarkPreset>
 	{
 		public WaymarkPreset()
 		{
@@ -213,6 +213,19 @@ namespace WaymarkPresetPlugin
 		public virtual bool ShouldSerializeTime()	//More JSON bullshit because it has to be polymorphic for the serializer to check it in a derived class apparently.
 		{
 			return true;
+		}
+
+		public bool Equals(WaymarkPreset other)
+		{
+			return A.Equals(other.A)
+				&& B.Equals(other.B)
+				&& C.Equals(other.C)
+				&& D.Equals(other.D)
+				&& One.Equals(other.One)
+				&& Two.Equals(other.Two)
+				&& Three.Equals(other.Three)
+				&& Four.Equals(other.Four)
+				&& MapID == other.MapID;
 		}
 	}
 

--- a/WaymarkPresetPlugin/WaymarkPreset.cs
+++ b/WaymarkPresetPlugin/WaymarkPreset.cs
@@ -40,51 +40,51 @@ namespace WaymarkPresetPlugin
 			}
 			WaymarkPreset preset = new WaymarkPreset();
 
-			preset.A.X = BitConverter.ToInt32( rawData, 0 ) / 1000.0f;
-			preset.A.Y = BitConverter.ToInt32( rawData, 4 ) / 1000.0f;
-			preset.A.Z = BitConverter.ToInt32( rawData, 8 ) / 1000.0f;
+			preset.A.X = BitConverter.ToInt32( rawData, 0 );
+			preset.A.Y = BitConverter.ToInt32( rawData, 4 );
+			preset.A.Z = BitConverter.ToInt32( rawData, 8 );
 			preset.A.Active = ( rawData[96] & 0b00000001 ) > 0;
 			preset.A.ID = 0;
 
-			preset.B.X = BitConverter.ToInt32( rawData, 12 ) / 1000.0f;
-			preset.B.Y = BitConverter.ToInt32( rawData, 16 ) / 1000.0f;
-			preset.B.Z = BitConverter.ToInt32( rawData, 20 ) / 1000.0f;
+			preset.B.X = BitConverter.ToInt32( rawData, 12 );
+			preset.B.Y = BitConverter.ToInt32( rawData, 16 );
+			preset.B.Z = BitConverter.ToInt32( rawData, 20 );
 			preset.B.Active = ( rawData[96] & 0b00000010 ) > 0;
 			preset.B.ID = 1;
 
-			preset.C.X = BitConverter.ToInt32( rawData, 24 ) / 1000.0f;
-			preset.C.Y = BitConverter.ToInt32( rawData, 28 ) / 1000.0f;
-			preset.C.Z = BitConverter.ToInt32( rawData, 32 ) / 1000.0f;
+			preset.C.X = BitConverter.ToInt32( rawData, 24 );
+			preset.C.Y = BitConverter.ToInt32( rawData, 28 );
+			preset.C.Z = BitConverter.ToInt32( rawData, 32 );
 			preset.C.Active = ( rawData[96] & 0b00000100 ) > 0;
 			preset.C.ID = 2;
 
-			preset.D.X = BitConverter.ToInt32( rawData, 36 ) / 1000.0f;
-			preset.D.Y = BitConverter.ToInt32( rawData, 40 ) / 1000.0f;
-			preset.D.Z = BitConverter.ToInt32( rawData, 44 ) / 1000.0f;
+			preset.D.X = BitConverter.ToInt32( rawData, 36 );
+			preset.D.Y = BitConverter.ToInt32( rawData, 40 );
+			preset.D.Z = BitConverter.ToInt32( rawData, 44 );
 			preset.D.Active = ( rawData[96] & 0b00001000 ) > 0;
 			preset.D.ID = 3;
 
-			preset.One.X = BitConverter.ToInt32( rawData, 48 ) / 1000.0f;
-			preset.One.Y = BitConverter.ToInt32( rawData, 52 ) / 1000.0f;
-			preset.One.Z = BitConverter.ToInt32( rawData, 56 ) / 1000.0f;
+			preset.One.X = BitConverter.ToInt32( rawData, 48 );
+			preset.One.Y = BitConverter.ToInt32( rawData, 52 );
+			preset.One.Z = BitConverter.ToInt32( rawData, 56 );
 			preset.One.Active = ( rawData[96] & 0b00010000 ) > 0;
 			preset.One.ID = 4;
 
-			preset.Two.X = BitConverter.ToInt32( rawData, 60 ) / 1000.0f;
-			preset.Two.Y = BitConverter.ToInt32( rawData, 64 ) / 1000.0f;
-			preset.Two.Z = BitConverter.ToInt32( rawData, 68 ) / 1000.0f;
+			preset.Two.X = BitConverter.ToInt32( rawData, 60 );
+			preset.Two.Y = BitConverter.ToInt32( rawData, 64 );
+			preset.Two.Z = BitConverter.ToInt32( rawData, 68 );
 			preset.Two.Active = ( rawData[96] & 0b00100000 ) > 0;
 			preset.Two.ID = 5;
 
-			preset.Three.X = BitConverter.ToInt32( rawData, 72 ) / 1000.0f;
-			preset.Three.Y = BitConverter.ToInt32( rawData, 76 ) / 1000.0f;
-			preset.Three.Z = BitConverter.ToInt32( rawData, 80 ) / 1000.0f;
+			preset.Three.X = BitConverter.ToInt32( rawData, 72 );
+			preset.Three.Y = BitConverter.ToInt32( rawData, 76 );
+			preset.Three.Z = BitConverter.ToInt32( rawData, 80 );
 			preset.Three.Active = ( rawData[96] & 0b01000000 ) > 0;
 			preset.Three.ID = 6;
 
-			preset.Four.X = BitConverter.ToInt32( rawData, 84 ) / 1000.0f;
-			preset.Four.Y = BitConverter.ToInt32( rawData, 88 ) / 1000.0f;
-			preset.Four.Z = BitConverter.ToInt32( rawData, 92 ) / 1000.0f;
+			preset.Four.X = BitConverter.ToInt32( rawData, 84 );
+			preset.Four.Y = BitConverter.ToInt32( rawData, 88 );
+			preset.Four.Z = BitConverter.ToInt32( rawData, 92 );
 			preset.Four.Active = ( rawData[96] & 0b10000000 ) > 0;
 			preset.Four.ID = 7;
 
@@ -101,37 +101,37 @@ namespace WaymarkPresetPlugin
 			List<byte> byteData = new List<byte>();
 
 			//	Waymark coordinates.
-			byteData.AddRange( BitConverter.GetBytes( A.Active ? (Int32)( A.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( A.Active ? (Int32)( A.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( A.Active ? (Int32)( A.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( A.Active ? A.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( A.Active ? A.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( A.Active ? A.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( B.Active ? (Int32)( B.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( B.Active ? (Int32)( B.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( B.Active ? (Int32)( B.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( B.Active ? B.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( B.Active ? B.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( B.Active ? B.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( C.Active ? (Int32)( C.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( C.Active ? (Int32)( C.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( C.Active ? (Int32)( C.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( C.Active ? C.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( C.Active ? C.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( C.Active ? C.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( D.Active ? (Int32)( D.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( D.Active ? (Int32)( D.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( D.Active ? (Int32)( D.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( D.Active ? D.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( D.Active ? D.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( D.Active ? D.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( One.Active ? (Int32)( One.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( One.Active ? (Int32)( One.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( One.Active ? (Int32)( One.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( One.Active ? One.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( One.Active ? One.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( One.Active ? One.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( Two.Active ? (Int32)( Two.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Two.Active ? (Int32)( Two.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Two.Active ? (Int32)( Two.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Two.Active ? Two.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Two.Active ? Two.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Two.Active ? Two.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( Three.Active ? (Int32)( Three.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Three.Active ? (Int32)( Three.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Three.Active ? (Int32)( Three.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Three.Active ? Three.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Three.Active ? Three.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Three.Active ? Three.Z : 0 ) );
 
-			byteData.AddRange( BitConverter.GetBytes( Four.Active ? (Int32)( Four.X * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Four.Active ? (Int32)( Four.Y * 1000.0 ) : 0 ) );
-			byteData.AddRange( BitConverter.GetBytes( Four.Active ? (Int32)( Four.Z * 1000.0 ) : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Four.Active ? Four.X : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Four.Active ? Four.Y : 0 ) );
+			byteData.AddRange( BitConverter.GetBytes( Four.Active ? Four.Z : 0 ) );
 
 			//	Which waymarks are active.
 			byte activeMask = 0x00;
@@ -157,7 +157,7 @@ namespace WaymarkPresetPlugin
 			//	Shouldn't ever come up with the wrong length, but just in case...
 			if( byteData.Count != 104 )
 			{
-				throw new Exception( "Error in WaymarkPreset.ConstructGamePreset(): Constructed byte array was of an unexpected length." );
+				throw new Exception( $"Error in WaymarkPreset.ConstructGamePreset(): Constructed byte array was of an unexpected length." );
 			}
 
 			//	Send it out.
@@ -198,17 +198,33 @@ namespace WaymarkPresetPlugin
 		public delegate string GetZoneNameDelegate( UInt16 zoneID, bool showID );
 
 		//	This looks gross, but it's easier to be compatible with PP presets if we have each waymark be a named member instead of in a collection :(
-		public string Name { get; set; } = "Unknown";
+		public string Name = "Unknown";
 		[JsonConverter( typeof( MapIDJsonConverter ) )] public UInt16 MapID { get; set; } = 0;	//PP sometimes gives bogus MapIDs that are outside the UInt16, so use a converter to handle those.
 		public DateTimeOffset Time { get; set; } = new DateTimeOffset( DateTimeOffset.Now.UtcDateTime );
-		public Waymark A { get; set; } = new Waymark();
-		public Waymark B { get; set; } = new Waymark();
-		public Waymark C { get; set; } = new Waymark();
-		public Waymark D { get; set; } = new Waymark();
-		public Waymark One { get; set; } = new Waymark();
-		public Waymark Two { get; set; } = new Waymark();
-		public Waymark Three { get; set; } = new Waymark();
-		public Waymark Four { get; set; } = new Waymark();
+		public Waymark A { get; set; } = new Waymark("A");
+		public Waymark B { get; set; } = new Waymark("B");
+		public Waymark C { get; set; } = new Waymark("C");
+		public Waymark D { get; set; } = new Waymark("D");
+		public Waymark One { get; set; } = new Waymark("1");
+		public Waymark Two { get; set; } = new Waymark("2");
+		public Waymark Three { get; set; } = new Waymark("3");
+		public Waymark Four { get; set; } = new Waymark("4");
+
+		[JsonIgnore]
+		public IEnumerable<Waymark> Waymarks
+		{
+			get
+			{
+				yield return A;
+				yield return B;
+				yield return C;
+				yield return D;
+				yield return One;
+				yield return Two;
+				yield return Three;
+				yield return Four;
+			}
+		}
 
 		public virtual bool ShouldSerializeTime()	//More JSON bullshit because it has to be polymorphic for the serializer to check it in a derived class apparently.
 		{


### PR DESCRIPTION
Adds 2 options to the waymark menu
![image](https://user-images.githubusercontent.com/70926398/93434839-7e319300-f87d-11ea-8ac9-b7620ac82aef.png)

### Summary
On entering an instance, the auto load option will automatically pull the first 5 presets for that instance from the library and load them to slots 1-5 in game.

On leaving an instance, the auto save option will check if any of the waymark slots are for that instance, and saves them in the library if they haven't been saved before.

This improves usability of the plugin because it makes user interaction with the UI components optional and automates filling the waymark slots for each instance.

### Things that could be improved

1. If the waymark library contains less than 5 presets and auto load is enabled, the first few waymark slots will get overwritten, and the remaining waymark slots will be unchanged. It would be better to clear the remaining slots so that the waymark list reflects the current instance.
    - This is not implemented because I don't know the proper way to clear a waymark slot from the game memory
2. Enable selecting which waymarks to auto-populate, instead of selecting the first 5 in the list
    - In order to implement this cleanly, the waymark library should be refactored to group presets based on map, so that each map can have up to 5 autoload presets, which is outside the scope of this PR.
