### PR TITLE
Added a zone search box to the library window.

### DIFF
--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -155,6 +155,20 @@ namespace WaymarkPresetPlugin
 					ImGui.PopStyleColor();
 					ImGui.PopStyleColor();
 				}
+
+				// The string to use for filtering the list of zones
+				var zoneFilterString = "";
+
+				// Show the search text box when not filtering on current zone
+				if (!mConfiguration.FilterOnCurrentZone && mConfiguration.SortPresetsByZone)
+				{
+					ImGui.PushItemWidth(ImGui.CalcTextSize("_").X * 20u);
+					ImGui.InputText(Loc.Localize("Search Input Text: Search", "Search"), ref mSearchText, 16u);
+					ImGui.PopItemWidth();
+
+					zoneFilterString = mSearchText;
+				}
+
 				int indexToMove = -1;
 				int indexToMoveTo = -1;
 				bool moveToAfter = false;
@@ -168,7 +182,9 @@ namespace WaymarkPresetPlugin
 						{
 							if( !mConfiguration.FilterOnCurrentZone || zone.Key == ZoneInfoHandler.GetContentFinderIDFromTerritoryTypeID( mClientState.TerritoryType ) )
 							{
-								if( ImGui.CollapsingHeader( ZoneInfoHandler.GetZoneInfoFromContentFinderID( zone.Key ).DutyName.ToString() ) )
+								var zoneInfo = ZoneInfoHandler.GetZoneInfoFromContentFinderID( zone.Key );
+
+								if ( IsZoneFilteredBySearch( zoneFilterString, zoneInfo ) && ImGui.CollapsingHeader( zoneInfo.DutyName.ToString() ) )
 								{
 									var indices = zone.Value;
 									for( int i = 0; i < indices.Count; ++i )
@@ -494,6 +510,13 @@ namespace WaymarkPresetPlugin
 
 		public Vector2 WindowPos { get; private set; }
 		public Vector2 WindowSize { get; private set; }
+		
+		private bool IsZoneFilteredBySearch(string zoneFilterString, ZoneInfo zoneInfo)
+		{
+			var matchingZones = LibraryWindowZoneSearcher.GetMatchingZones(zoneFilterString);
+			
+			return zoneFilterString.Length == 0 || matchingZones.Any(id => id == zoneInfo.ContentFinderConditionID);
+		}
 
 		private readonly PluginUI mUI;
 		private readonly DalamudPluginInterface mPluginInterface;
@@ -513,5 +536,8 @@ namespace WaymarkPresetPlugin
 		private bool FieldMarkerAddonWasOpen { get; set; } = false;
 
 		private readonly IntPtr mpLibraryPresetDragAndDropData;
+		
+		private ZoneSearcher LibraryWindowZoneSearcher { get; set; } = new ZoneSearcher();
+		private string mSearchText = "";
 	}
 }

--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -160,10 +160,10 @@ namespace WaymarkPresetPlugin
 				var zoneFilterString = "";
 
 				// Show the search text box when not filtering on current zone
-				if (!mConfiguration.FilterOnCurrentZone && mConfiguration.SortPresetsByZone)
+				if( !mConfiguration.FilterOnCurrentZone && mConfiguration.SortPresetsByZone )
 				{
-					ImGui.PushItemWidth(ImGui.CalcTextSize("_").X * 20u);
-					ImGui.InputText(Loc.Localize("Search Input Text: Search", "Search"), ref mSearchText, 16u);
+					ImGui.PushItemWidth( ImGui.CalcTextSize( "_" ).X * 20u );
+					ImGui.InputText( Loc.Localize( "Search Input Text: Search", "Search" ), ref mSearchText, 16u );
 					ImGui.PopItemWidth();
 
 					zoneFilterString = mSearchText;
@@ -184,7 +184,7 @@ namespace WaymarkPresetPlugin
 							{
 								var zoneInfo = ZoneInfoHandler.GetZoneInfoFromContentFinderID( zone.Key );
 
-								if ( IsZoneFilteredBySearch( zoneFilterString, zoneInfo ) && ImGui.CollapsingHeader( zoneInfo.DutyName.ToString() ) )
+								if( IsZoneFilteredBySearch( zoneFilterString, zoneInfo ) && ImGui.CollapsingHeader( zoneInfo.DutyName.ToString() ) )
 								{
 									var indices = zone.Value;
 									for( int i = 0; i < indices.Count; ++i )
@@ -511,11 +511,11 @@ namespace WaymarkPresetPlugin
 		public Vector2 WindowPos { get; private set; }
 		public Vector2 WindowSize { get; private set; }
 		
-		private bool IsZoneFilteredBySearch(string zoneFilterString, ZoneInfo zoneInfo)
+		private bool IsZoneFilteredBySearch( string zoneFilterString, ZoneInfo zoneInfo )
 		{
-			var matchingZones = LibraryWindowZoneSearcher.GetMatchingZones(zoneFilterString);
+			var matchingZones = LibraryWindowZoneSearcher.GetMatchingZones( zoneFilterString );
 			
-			return zoneFilterString.Length == 0 || matchingZones.Any(id => id == zoneInfo.ContentFinderConditionID);
+			return zoneFilterString.Length == 0 || matchingZones.Any( id => id == zoneInfo.ContentFinderConditionID );
 		}
 
 		private readonly PluginUI mUI;


### PR DESCRIPTION
![2022-05-15 20_15_29-FINAL FANTASY XIV](https://user-images.githubusercontent.com/99750849/168506464-13a46003-3a11-4947-b573-b6ebd1cef624.png)
 
![pwaymark-search-2-2fe21a1994](https://user-images.githubusercontent.com/99750849/168507010-2c1a07cb-28c2-4977-8fb2-d0f1529fe818.gif)

After my suggestion here https://github.com/PunishedPineapple/WaymarkPresetPlugin/issues/3#issuecomment-1127007291 I saw that there was already search functionality to filter by zone name in the preset editor, so I reused that. The zone search box disappears (and its functionality is disabled) when filter on current zone is on or categorize presets by zone is off.