### PR TITLE
Double click to place preset

### DIFF
--- a/WaymarkPresetPlugin/UI/Window_Editor.cs
+++ b/WaymarkPresetPlugin/UI/Window_Editor.cs
@@ -163,7 +163,7 @@ namespace WaymarkPresetPlugin
 				{
 					CancelEditing();
 				}
-				ImGui.SameLine( ImGui.GetWindowContentRegionWidth() - ImGui.CalcTextSize( "Map View" ).X - ImGui.GetStyle().FramePadding.X * 2 );
+				ImGui.SameLine( ImGui.GetWindowContentRegionMax().X - ImGui.CalcTextSize( "Map View" ).X - ImGui.GetStyle().FramePadding.X * 2 );
 				if( ImGui.Button( Loc.Localize( "Button: Map View", "Map View" ) + "###Map View Button" ) )
 				{
 					mUI.MapWindow.WindowVisible = !mUI.MapWindow.WindowVisible;

--- a/WaymarkPresetPlugin/UI/Window_Help.cs
+++ b/WaymarkPresetPlugin/UI/Window_Help.cs
@@ -62,7 +62,7 @@ namespace WaymarkPresetPlugin
 
 				if( ImGui.BeginChild( "###Help Text Pane" ) )
 				{
-					ImGui.PushTextWrapPos( ImGui.GetWindowContentRegionWidth() );
+					ImGui.PushTextWrapPos( ImGui.GetWindowContentRegionMax().X );
 					switch( mCurrentHelpPage )
 					{
 						case HelpWindowPage.General: DrawHelpWindow_General(); break;
@@ -183,9 +183,9 @@ namespace WaymarkPresetPlugin
 			{
 				const float imgWidthScale = 0.75f;
 				const float imguiPaddingScale = 1.0f - imgWidthScale;
-				ImGui.Indent( ImGui.GetWindowContentRegionWidth() * imguiPaddingScale / 2f );
+				ImGui.Indent( ImGui.GetWindowContentRegionMax().X * imguiPaddingScale / 2f );
 				var size = new Vector2( mCoordinateSystemsDiagram.Width, mCoordinateSystemsDiagram.Height );
-				size *= ImGui.GetWindowContentRegionWidth() / mCoordinateSystemsDiagram.Width * imgWidthScale;
+				size *= ImGui.GetWindowContentRegionMax().X / mCoordinateSystemsDiagram.Width * imgWidthScale;
 				ImGui.Image( mCoordinateSystemsDiagram.ImGuiHandle, size );
 				ImGui.Unindent();
 			}

--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -304,10 +304,10 @@ namespace WaymarkPresetPlugin
 				}
 
 				// Place preset when its entry in the library window is double clicked.
-				if ( ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
+				if ( SelectedPreset >= 0 && ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
 				{
 					var preset = mConfiguration.PresetLibrary.Presets[SelectedPreset].GetAsGamePreset();
-					
+				
 					MemoryHandler.PlacePreset( preset );
 				}
 

--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -302,6 +302,15 @@ namespace WaymarkPresetPlugin
 						mUI.InfoPaneWindow.CancelPendingDelete();
 					}
 				}
+
+				// Place preset when its entry in the library window is double clicked.
+				if ( ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
+				{
+					var preset = mConfiguration.PresetLibrary.Presets[SelectedPreset].GetAsGamePreset();
+					
+					MemoryHandler.PlacePreset( preset );
+				}
+
 				if( !mUI.EditorWindow.EditingPreset && mConfiguration.AllowPresetDragAndDropOrdering && ImGui.BeginDragDropSource( ImGuiDragDropFlags.SourceNoHoldToOpenOthers ) )
 				{
 					ImGui.SetDragDropPayload( $"PresetIdxZ{zonePresets.Key}", mpLibraryPresetDragAndDropData, sizeof( int ) );

--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -285,12 +285,12 @@ namespace WaymarkPresetPlugin
 			var indices = zonePresets.Value;
 			for( int i = 0; i < indices.Count; ++i )
 			{
-				if( ImGui.Selectable( $"{mConfiguration.PresetLibrary.Presets[indices[i]].Name}{( mConfiguration.ShowLibraryIndexInPresetInfo ? " (" + indices[i].ToString() + ")" : "" )}###_Preset_{indices[i]}", indices[i] == SelectedPreset ) )
+				if( ImGui.Selectable( $"{mConfiguration.PresetLibrary.Presets[indices[i]].Name}{( mConfiguration.ShowLibraryIndexInPresetInfo ? " (" + indices[i].ToString() + ")" : "" )}###_Preset_{indices[i]}", indices[i] == SelectedPreset, ImGuiSelectableFlags.AllowDoubleClick ) )
 				{
 					//	It's probably a bad idea to allow the selection to change when a preset's being edited.
 					if( !mUI.EditorWindow.EditingPreset )
 					{
-						if( mConfiguration.AllowUnselectPreset && indices[i] == SelectedPreset )
+						if( mConfiguration.AllowUnselectPreset && indices[i] == SelectedPreset && !ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
 						{
 							SelectedPreset = -1;
 						}
@@ -301,14 +301,14 @@ namespace WaymarkPresetPlugin
 
 						mUI.InfoPaneWindow.CancelPendingDelete();
 					}
-				}
 
-				// Place preset when its entry in the library window is double clicked.
-				if ( SelectedPreset >= 0 && ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
-				{
-					var preset = mConfiguration.PresetLibrary.Presets[SelectedPreset].GetAsGamePreset();
-				
-					MemoryHandler.PlacePreset( preset );
+					// Place preset when its entry in the library window is double clicked.
+					if( SelectedPreset >= 0 && ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) )
+					{
+						var preset = mConfiguration.PresetLibrary.Presets[SelectedPreset].GetAsGamePreset();
+
+						MemoryHandler.PlacePreset( preset );
+					}
 				}
 
 				if( !mUI.EditorWindow.EditingPreset && mConfiguration.AllowPresetDragAndDropOrdering && ImGui.BeginDragDropSource( ImGuiDragDropFlags.SourceNoHoldToOpenOthers ) )

--- a/WaymarkPresetPlugin/UI/Window_Library.cs
+++ b/WaymarkPresetPlugin/UI/Window_Library.cs
@@ -106,7 +106,7 @@ namespace WaymarkPresetPlugin
 				ImGui.Checkbox( Loc.Localize( "Config Option: Filter on Current Zone", "Filter on Current Zone" ) + "###Filter on Current Zone Checkbox", ref mConfiguration.mFilterOnCurrentZone );
 				if( mConfiguration.FilterOnCurrentZone != previouslyFilteredOnZone ) mConfiguration.Save(); //	I'd rather just save the state when the plugin is unloaded, but that's not been feasible in the past.
 				string saveCurrentWaymarksButtonText = Loc.Localize( "Button: Save Current Waymarks", "Save Current Waymarks" );
-				ImGui.SameLine( ImGui.GetWindowContentRegionWidth() - ImGui.CalcTextSize( saveCurrentWaymarksButtonText ).X - ImGui.GetStyle().FramePadding.X * 2 + ImGui.GetStyle().WindowPadding.X );
+				ImGui.SameLine( ImGui.GetWindowContentRegionMax().X - ImGui.CalcTextSize( saveCurrentWaymarksButtonText ).X - ImGui.GetStyle().FramePadding.X * 2 + ImGui.GetStyle().WindowPadding.X );
 				if( MemoryHandler.FoundDirectSaveSigs() )
 				{
 					if( ImGui.Button( saveCurrentWaymarksButtonText + "###Save Current Waymarks Button" ) )

--- a/WaymarkPresetPlugin/UI/Window_Settings.cs
+++ b/WaymarkPresetPlugin/UI/Window_Settings.cs
@@ -113,7 +113,7 @@ namespace WaymarkPresetPlugin
 				}
 
 				string showLibraryButtonString = Loc.Localize( "Button: Show Library", "Show Library" );
-				ImGui.SameLine( ImGui.GetWindowContentRegionWidth() - ImGui.CalcTextSize( showLibraryButtonString ).X - ImGui.GetStyle().FramePadding.X * 2 );
+				ImGui.SameLine( ImGui.GetWindowContentRegionMax().X - ImGui.CalcTextSize( showLibraryButtonString ).X - ImGui.GetStyle().FramePadding.X * 2 );
 				if( ImGui.Button( showLibraryButtonString + "###Show Library Button" ) )
 				{
 					mUI.LibraryWindow.WindowVisible = true;


### PR DESCRIPTION
This change allows placing a preset by double clicking its entry in the library window, useful for those who place presets directly from the plugin UI instead of the game's waymarks window.

While this makes it easier to place a single preset, it also makes it quicker to switch between presets. A use case for this is in a savage PF group (on NA) when assigning positions and roles before the first pull. Because NA unfortunately doesn't use macros, this setup often involves multiple waymark configurations as shown in the gif below:

![double_click_to_place_preset](https://user-images.githubusercontent.com/99750849/178594093-1857bf2a-6d86-41fb-b11c-0dc9ebc9ec56.gif)

For testing, I made sure that this change doesn't interact adversely with click to unselect preset turned on.