### PR TITLE
Add some preset quickplace waymark presets

### DIFF
--- a/WaymarkPresetPlugin/MathUtils.cs
+++ b/WaymarkPresetPlugin/MathUtils.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WaymarkPresetPlugin
+{
+    internal static class MathUtils
+    {
+        public static Vector3[] ComputeRadialPositions(Vector3 center, float radius_Yalms, int numPoints, float angleOffset_Deg = 0f)
+        {
+            //	Can't have less than one point (even that doesn't make much sense, but it's technically allowable).
+            numPoints = Math.Max(1, numPoints);
+            var computedPoints = new Vector3[numPoints];
+
+            //	Zero azimuth is facing North (90 degrees)
+            angleOffset_Deg -= 90f;
+            double stepAngle_Deg = 360.0 / numPoints;
+
+            //	Compute the coordinates on the circle about the center point.
+            for (int i = 0; i < numPoints; ++i)
+            {
+                //	Because of FFXIV's coordinate system, we need to go backward in angle.
+                double angle_Rad = (i * stepAngle_Deg + angleOffset_Deg) * Math.PI / 180.0;
+                computedPoints[i].X = (float)Math.Cos(angle_Rad);
+                computedPoints[i].Z = (float)Math.Sin(angle_Rad);
+                computedPoints[i] *= radius_Yalms;
+                computedPoints[i] += center;
+            }
+
+            return computedPoints;
+        }
+
+        public static Vector3[] ComputeSquarePositions(Vector3 center, float s)
+        {
+            return new Vector3[]
+            {
+                center + new Vector3( 0, 0, -s),
+                center + new Vector3( s, 0, -s),
+                center + new Vector3( s, 0,  0),
+                center + new Vector3( s, 0,  s),
+                center + new Vector3( 0, 0,  s),
+                center + new Vector3(-s, 0,  s),
+                center + new Vector3(-s, 0,  0),
+                center + new Vector3(-s, 0, -s),
+            };
+        }
+
+        public static int Mod2(int a, int b) {
+            if (a == 0)
+            {
+                return 0;
+            }
+            else if (a % b == 0)
+            {
+                return b;
+            }
+            else
+            {
+                return a % b;
+            }
+        }
+    }
+}

--- a/WaymarkPresetPlugin/UI/Window_Help.cs
+++ b/WaymarkPresetPlugin/UI/Window_Help.cs
@@ -13,6 +13,8 @@ using ImGuiNET;
 
 using ImGuiScene;
 
+using static WaymarkPresetPlugin.MathUtils;
+
 namespace WaymarkPresetPlugin
 {
 	internal sealed class Window_Help : IDisposable
@@ -285,30 +287,6 @@ namespace WaymarkPresetPlugin
 					mUI.LibraryWindow.TrySetSelectedPreset( newPresetIndex );
 				}
 			}
-		}
-
-		private Vector3[] ComputeRadialPositions( Vector3 center, float radius_Yalms, int numPoints, float angleOffset_Deg = 0f )
-		{
-			//	Can't have less than one point (even that doesn't make much sense, but it's technically allowable).
-			numPoints = Math.Max( 1, numPoints );
-			var computedPoints = new Vector3[numPoints];
-
-			//	Zero azimuth is facing North (90 degrees)
-			angleOffset_Deg -= 90f;
-			double stepAngle_Deg = 360.0 / numPoints;
-
-			//	Compute the coordinates on the circle about the center point.
-			for( int i = 0; i < numPoints; ++i )
-			{
-				//	Because of FFXIV's coordinate system, we need to go backward in angle.
-				double angle_Rad = ( i * stepAngle_Deg + angleOffset_Deg ) * Math.PI / 180.0;
-				computedPoints[i].X = (float)Math.Cos( angle_Rad );
-				computedPoints[i].Z = (float)Math.Sin( angle_Rad );
-				computedPoints[i] *= radius_Yalms;
-				computedPoints[i] += center;
-			}
-
-			return computedPoints;
 		}
 
 		public void OpenHelpWindow( HelpWindowPage page )


### PR DESCRIPTION
This adds a couple commonly used waymark presets, so that users don't have to create/import anything to use them. While this functionality does exist already using the `/place` command, it requires the users to import the waymark presets that they want to place first.

- Circle - 8 markers in a circular arrangement, with same colors opposite of each other
- CircleB - 8 markers in a circular arrangement, with same colors paired together
- Square - 8 markers in a square arrangement, with same colors opposite of each other
- SquareB - 8 markers in a square arrangement, with same colors paired together
- PFLine - A marker formation that Aether PF uses to assign "line" positions
- PFQuickmarch - A marker formation that Aether PF uses to assign "quickmarch" positions

These presets are hardcoded for an arena center of `(100, 0, 100)`, which have been the usual arena centers for all recent content.