### PR TITLE
Fix Sig Collision

### DIFF
--- a/WaymarkPresetPlugin/MemoryHandler.cs
+++ b/WaymarkPresetPlugin/MemoryHandler.cs
@@ -34,7 +34,7 @@ namespace WaymarkPresetPlugin
 			//	Get Function Pointers, etc.
 			try
 			{
-				IntPtr fpGetUISAVESectionAddress = sigScanner.ScanText( "40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 0F B7 DA" );
+				IntPtr fpGetUISAVESectionAddress = sigScanner.ScanText( "40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 0F B7 DA E8 ?? ?? ?? ?? 4C 8B C0" );
 				if( fpGetUISAVESectionAddress != IntPtr.Zero )
 				{
 					mdGetUISAVESectionAddress = Marshal.GetDelegateForFunctionPointer<GetConfigSectionDelegate>( fpGetUISAVESectionAddress );


### PR DESCRIPTION
As I was checking the sigs of the plugins I have the source code handy, I found this sig has multiple collisions.

Fortunately, the desired function is the first of the collisions, so it resolves properly, this PR includes a new sig that resolves these collisions.

This sig I am PRing is correct as of 6.31

You could choose to ignore this PR, as the sig does correctly resolve for now, however, in the future that may no longer be the case.

![image](https://user-images.githubusercontent.com/9083275/214241068-e884c21c-5ecb-4912-9709-b9e8158ed8a3.png)
